### PR TITLE
Handle missing trailing message deletions gracefully

### DIFF
--- a/app/(chat)/actions.ts
+++ b/app/(chat)/actions.ts
@@ -4,6 +4,7 @@ import { generateText, type UIMessage } from "ai";
 import { cookies } from "next/headers";
 import type { VisibilityType } from "@/components/visibility-selector";
 import { myProvider } from "@/lib/ai/providers";
+import { ChatSDKError } from "@/lib/errors";
 import {
   deleteMessagesByChatIdAfterTimestamp,
   getMessageById,
@@ -35,6 +36,13 @@ export async function generateTitleFromUserMessage({
 
 export async function deleteTrailingMessages({ id }: { id: string }) {
   const [message] = await getMessageById({ id });
+
+  if (!message) {
+    throw new ChatSDKError(
+      "not_found:chat",
+      "The requested message could not be found."
+    );
+  }
 
   await deleteMessagesByChatIdAfterTimestamp({
     chatId: message.chatId,

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "db:pull": "drizzle-kit pull",
     "db:check": "drizzle-kit check",
     "db:up": "drizzle-kit up",
-    "test": "export PLAYWRIGHT=True && pnpm exec playwright test"
+    "test": "export PLAYWRIGHT=True && pnpm exec playwright test",
+    "test:unit": "vitest run"
   },
   "dependencies": {
     "@ai-sdk/gateway": "^1.0.15",
@@ -106,7 +107,8 @@
     "tailwindcss": "^4.1.13",
     "tsx": "^4.19.1",
     "typescript": "^5.6.3",
-    "ultracite": "5.3.9"
+    "ultracite": "5.3.9",
+    "vitest": "^3.2.4"
   },
   "packageManager": "pnpm@9.12.3"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -270,6 +270,9 @@ importers:
       ultracite:
         specifier: 5.3.9
         version: 5.3.9(@types/debug@4.1.12)(@types/node@22.13.10)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.19.3)(typescript@5.8.2)
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.13.10)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.19.3)
 
 packages:
 
@@ -3637,10 +3640,6 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@4.0.2:
-    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
-    engines: {node: '>=12'}
-
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
@@ -6823,7 +6822,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.8
 
   eventsource-parser@3.0.5: {}
 
@@ -7724,8 +7723,6 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@4.0.2: {}
-
   picomatch@4.0.3: {}
 
   pkg-types@1.3.1:
@@ -8569,7 +8566,7 @@ snapshots:
       expect-type: 1.2.2
       magic-string: 0.30.19
       pathe: 2.0.3
-      picomatch: 4.0.2
+      picomatch: 4.0.3
       std-env: 3.9.0
       tinybench: 2.9.0
       tinyexec: 0.3.2

--- a/tests/unit/app/chat/actions.test.ts
+++ b/tests/unit/app/chat/actions.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ChatSDKError } from "@/lib/errors";
+
+const mocks = vi.hoisted(() => ({
+  mockGetMessageById: vi.fn(),
+  mockDeleteMessagesByChatIdAfterTimestamp: vi.fn(),
+}));
+
+vi.mock("@/lib/db/queries", () => ({
+  getMessageById: mocks.mockGetMessageById,
+  deleteMessagesByChatIdAfterTimestamp:
+    mocks.mockDeleteMessagesByChatIdAfterTimestamp,
+}));
+
+import { deleteTrailingMessages } from "@/app/(chat)/actions";
+
+describe("deleteTrailingMessages", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.mockDeleteMessagesByChatIdAfterTimestamp.mockResolvedValue(undefined);
+  });
+
+  it("deletes trailing messages when the message exists", async () => {
+    const message = {
+      id: "message-1",
+      chatId: "chat-1",
+      createdAt: new Date("2024-01-01T00:00:00.000Z"),
+    };
+
+    mocks.mockGetMessageById.mockResolvedValueOnce([message]);
+
+    await deleteTrailingMessages({ id: message.id });
+
+    expect(
+      mocks.mockDeleteMessagesByChatIdAfterTimestamp
+    ).toHaveBeenCalledWith({
+      chatId: message.chatId,
+      timestamp: message.createdAt,
+    });
+  });
+
+  it("throws a ChatSDKError when the message is not found", async () => {
+    expect.assertions(3);
+
+    mocks.mockGetMessageById.mockResolvedValueOnce([]);
+
+    const error = await deleteTrailingMessages({ id: "missing-id" }).catch(
+      (currentError) => currentError as ChatSDKError
+    );
+
+    expect(error).toBeInstanceOf(ChatSDKError);
+    expect(error).toMatchObject({
+      type: "not_found",
+      surface: "chat",
+      cause: "The requested message could not be found.",
+    });
+    expect(
+      mocks.mockDeleteMessagesByChatIdAfterTimestamp
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vitest/config";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["tests/unit/**/*.test.ts"],
+    exclude: ["**/node_modules/**"],
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./"),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- guard the `deleteTrailingMessages` server action against missing messages by surfacing a `ChatSDKError`
- add unit coverage for trailing message deletion success and not-found cases
- configure Vitest-based unit test infrastructure and script for targeted runs

## Testing
- `pnpm test:unit`


------
https://chatgpt.com/codex/tasks/task_b_68d8790782d4832fb76859ee07c3ac0b