### PR TITLE
Add not-found handling to document delete API

### DIFF
--- a/app/(chat)/api/document/route.ts
+++ b/app/(chat)/api/document/route.ts
@@ -26,11 +26,11 @@ export async function GET(request: Request) {
 
   const documents = await getDocumentsById({ id });
 
-  const [document] = documents;
-
-  if (!document) {
+  if (documents.length === 0) {
     return new ChatSDKError("not_found:document").toResponse();
   }
+
+  const [document] = documents;
 
   if (document.userId !== session.user.id) {
     return new ChatSDKError("forbidden:document").toResponse();
@@ -110,6 +110,10 @@ export async function DELETE(request: Request) {
   }
 
   const documents = await getDocumentsById({ id });
+
+  if (documents.length === 0) {
+    return new ChatSDKError("not_found:document").toResponse();
+  }
 
   const [document] = documents;
 

--- a/tests/routes/document.test.ts
+++ b/tests/routes/document.test.ts
@@ -141,6 +141,19 @@ test.describe
       expect(message).toEqual(getMessageByErrorCode(code));
     });
 
+    test("Ada cannot delete a document that does not exist", async ({
+      adaContext,
+    }) => {
+      const response = await adaContext.request.delete(
+        `/api/document?id=${generateUUID()}&timestamp=${new Date().toISOString()}`
+      );
+      expect(response.status()).toBe(404);
+
+      const { code, message } = await response.json();
+      expect(code).toEqual("not_found:document");
+      expect(message).toEqual(getMessageByErrorCode(code));
+    });
+
     test("Ada can delete a document by specifying id and timestamp", async ({
       adaContext,
     }) => {


### PR DESCRIPTION
## Summary
- guard document GET and DELETE handlers against empty query results
- return a not_found:document error when attempting to delete a missing document
- cover the new error condition with an API test for DELETE /api/document

## Testing
- PLAYWRIGHT=True pnpm exec playwright test tests/routes/document.test.ts *(fails: missing Playwright browsers in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d8790b5ab0832f9442e46eb68d8b9f