### PR TITLE
Improve document timestamp bounds handling

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -75,10 +75,10 @@ export function getDocumentTimestampByIndex(
   documents: Document[],
   index: number,
 ) {
-  if (!documents) { return new Date(); }
-  if (index > documents.length) { return new Date(); }
+  if (!Array.isArray(documents)) { return new Date(); }
+  if (index < 0 || index >= documents.length) { return new Date(); }
 
-  return documents[index].createdAt;
+  return documents[index]?.createdAt ?? new Date();
 }
 
 export function getTrailingMessageId({

--- a/tests/unit/lib/utils.test.ts
+++ b/tests/unit/lib/utils.test.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { getDocumentTimestampByIndex } from '@/lib/utils';
+import type { Document } from '@/lib/db/schema';
+
+const createDocument = (overrides: Partial<Document> = {}): Document => ({
+  id: overrides.id ?? 'document-id',
+  createdAt: overrides.createdAt ?? new Date('2024-01-01T00:00:00.000Z'),
+  title: overrides.title ?? 'Example document',
+  content: overrides.content ?? 'Example content',
+  kind: overrides.kind ?? 'text',
+  userId: overrides.userId ?? 'user-id',
+});
+
+test('returns the document timestamp when the index is in range', () => {
+  const firstTimestamp = new Date('2024-01-01T00:00:00.000Z');
+  const secondTimestamp = new Date('2024-02-01T00:00:00.000Z');
+  const documents: Document[] = [
+    createDocument({ id: 'doc-1', createdAt: firstTimestamp }),
+    createDocument({ id: 'doc-2', createdAt: secondTimestamp }),
+  ];
+
+  const result = getDocumentTimestampByIndex(documents, 1);
+
+  assert.strictEqual(result, secondTimestamp);
+});
+
+test('returns a fallback timestamp when the index is out of range', () => {
+  const documents: Document[] = [
+    createDocument({ id: 'doc-1', createdAt: new Date('2024-01-01T00:00:00.000Z') }),
+  ];
+
+  const before = Date.now();
+  const result = getDocumentTimestampByIndex(documents, -1);
+  const after = Date.now();
+
+  assert.ok(result.getTime() >= before && result.getTime() <= after);
+});
+


### PR DESCRIPTION
## Summary
- tighten the document timestamp lookup guard to validate array indices and return a safe fallback
- add unit tests for in-range and out-of-range document indices

## Testing
- pnpm exec tsx --test tests/unit/lib/utils.test.ts

------
https://chatgpt.com/codex/tasks/task_b_68d8790ce0a4832fba5ceb1b73257cab