### PR TITLE
docs: refresh branding for Aquarius AI Copilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
-<a href="https://chat.vercel.ai/">
-  <img alt="Next.js 14 and App Router-ready AI chatbot." src="app/(chat)/opengraph-image.png">
-  <h1 align="center">Chat SDK</h1>
-</a>
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="/images/aquarius-logo-dark.svg">
+    <img alt="Aquarius AI Copilot" src="/images/aquarius-logo-light.svg" width="160" height="160">
+  </picture>
+</p>
+
+<h1 align="center">Aquarius AI Copilot Agent</h1>
 
 <p align="center">
-    Chat SDK is a free, open-source template built with Next.js and the AI SDK that helps you quickly build powerful chatbot applications.
+  Aquarius AI Copilot Agent is an open-source, production-grade multi-agent chat platform for computer-using agents, proudly crafted by <a href="https://t.me/likhonsheikh">Likhon Sheikh</a>.
 </p>
 
 <p align="center">
@@ -18,25 +22,24 @@
 
 ## Features
 
-- [Next.js](https://nextjs.org) App Router
-  - Advanced routing for seamless navigation and performance
-  - React Server Components (RSCs) and Server Actions for server-side rendering and increased performance
-- [AI SDK](https://ai-sdk.dev/docs/introduction)
-  - Unified API for generating text, structured objects, and tool calls with LLMs
-  - Hooks for building dynamic chat and generative user interfaces
-  - Supports xAI (default), OpenAI, Fireworks, and other model providers
-- [shadcn/ui](https://ui.shadcn.com)
-  - Styling with [Tailwind CSS](https://tailwindcss.com)
-  - Component primitives from [Radix UI](https://radix-ui.com) for accessibility and flexibility
-- Data Persistence
-  - [Neon Serverless Postgres](https://vercel.com/marketplace/neon) for saving chat history and user data
-  - [Vercel Blob](https://vercel.com/storage/blob) for efficient file storage
-- [Auth.js](https://authjs.dev)
-  - Simple and secure authentication
+- **Agentic orchestration**
+  - Modular multi-agent workflows with tool calling, artifact streaming, and resumable sessions
+  - Sandbox-ready computer-using agents (CUA) with safety guards and audit trails
+- **Next.js App Router foundation**
+  - React Server Components, Server Actions, and optimized routing for production scale
+  - Accessible UI built with [shadcn/ui](https://ui.shadcn.com) and [Tailwind CSS](https://tailwindcss.com)
+- **AI SDK integration**
+  - Unified API for LLM chat, function calls, and structured outputs
+  - Works with xAI (default), OpenAI, Fireworks, and other gateway providers
+- **Typed persistence**
+  - [Neon Serverless Postgres](https://vercel.com/marketplace/neon) via Drizzle ORM helpers
+  - Redis-backed streaming buffers and artifact storage with resumable recovery
+- **Secure authentication**
+  - [Auth.js](https://authjs.dev) guest and password flows with entitlements and rate limiting
 
 ## Model Providers
 
-This template uses the [Vercel AI Gateway](https://vercel.com/docs/ai-gateway) to access multiple AI models through a unified interface. The default configuration includes [xAI](https://x.ai) models (`grok-2-vision-1212`, `grok-3-mini`) routed through the gateway.
+Aquarius AI Copilot Agent uses the [Vercel AI Gateway](https://vercel.com/docs/ai-gateway) to access multiple AI models through a unified interface. The default configuration includes [xAI](https://x.ai) models (`grok-2-vision-1212`, `grok-3-mini`) routed through the gateway.
 
 ### AI Gateway Authentication
 
@@ -48,13 +51,13 @@ With the [AI SDK](https://ai-sdk.dev/docs/introduction), you can also switch to 
 
 ## Deploy Your Own
 
-You can deploy your own version of the Next.js AI Chatbot to Vercel with one click:
+You can deploy your own version of Aquarius AI Copilot Agent to Vercel with one click:
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/templates/next.js/nextjs-ai-chatbot)
 
 ## Running locally
 
-You will need to use the environment variables [defined in `.env.example`](.env.example) to run Next.js AI Chatbot. It's recommended you use [Vercel Environment Variables](https://vercel.com/docs/projects/environment-variables) for this, but a `.env` file is all that is necessary.
+You will need to use the environment variables [defined in `.env.example`](.env.example) to run Aquarius AI Copilot Agent. It's recommended you use [Vercel Environment Variables](https://vercel.com/docs/projects/environment-variables) for this, but a `.env` file is all that is necessary.
 
 > Note: You should not commit your `.env` file or it will expose secrets that will allow others to control access to your various AI and authentication provider accounts.
 
@@ -67,4 +70,4 @@ pnpm install
 pnpm dev
 ```
 
-Your app template should now be running on [localhost:3000](http://localhost:3000).
+Your Aquarius deployment should now be running on [localhost:3000](http://localhost:3000).

--- a/public/images/aquarius-logo-dark.svg
+++ b/public/images/aquarius-logo-dark.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-labelledby="title desc">
+  <title id="title">Aquarius Logo Dark</title>
+  <desc id="desc">Diamond shaped Aquarius brand mark with a metallic silver gradient fill.</desc>
+  <defs>
+    <linearGradient id="silver" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#fafafa" />
+      <stop offset="25%" stop-color="#d9d9d9" />
+      <stop offset="50%" stop-color="#9e9e9e" />
+      <stop offset="75%" stop-color="#cfcfcf" />
+      <stop offset="100%" stop-color="#f5f5f5" />
+    </linearGradient>
+  </defs>
+  <g fill="none" stroke-width="0">
+    <path fill="url(#silver)" d="M128 8l120 120-120 120L8 128z" />
+    <path fill="#05070a" d="M128 68l60 60-60 60-60-60z" opacity="0.75" />
+  </g>
+</svg>

--- a/public/images/aquarius-logo-light.svg
+++ b/public/images/aquarius-logo-light.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-labelledby="title desc">
+  <title id="title">Aquarius Logo Light</title>
+  <desc id="desc">Diamond shaped Aquarius brand mark with a rainbow gradient fill.</desc>
+  <defs>
+    <linearGradient id="gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ff5f6d" />
+      <stop offset="25%" stop-color="#ffc371" />
+      <stop offset="50%" stop-color="#47cf73" />
+      <stop offset="75%" stop-color="#2bc0e4" />
+      <stop offset="100%" stop-color="#845ef7" />
+    </linearGradient>
+  </defs>
+  <g fill="none" stroke-width="0">
+    <path fill="url(#gradient)" d="M128 8l120 120-120 120L8 128z" />
+    <path fill="#0c1c2c" d="M128 68l60 60-60 60-60-60z" opacity="0.8" />
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- add light and dark Aquarius Copilot logo variants for documentation use
- refresh README branding to highlight the open-source project led by Likhon Sheikh and outline key capabilities

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d87c1bb440832faac53b876edbb247