### PR TITLE
Fix credentials authorize logic and dummy password helpers

### DIFF
--- a/app/(auth)/auth.ts
+++ b/app/(auth)/auth.ts
@@ -1,13 +1,20 @@
 import NextAuth, { type DefaultSession } from "next-auth";
 import type { DefaultJWT } from "next-auth/jwt";
 import Credentials from "next-auth/providers/credentials";
+
 import { getDummyPassword } from "@/lib/constants";
 import { createGuestUser, getUser } from "@/lib/db/queries";
 import { ChatSDKError } from "@/lib/errors";
 import { verifyPassword } from "@/lib/security/bcrypt";
+
 import { authConfig } from "./auth.config";
 
 export type UserType = "guest" | "regular";
+
+type CredentialsAuthorizePayload = {
+  email?: unknown;
+  password?: unknown;
+};
 
 const normalizeCredential = (value: unknown, label: string): string => {
   if (typeof value !== "string" || value.trim().length === 0) {
@@ -53,7 +60,22 @@ export const {
   providers: [
     Credentials({
       credentials: {},
-      async authorize({ email, password }: any) {
+      async authorize(credentials: CredentialsAuthorizePayload | undefined) {
+        if (!credentials) {
+          return null;
+        }
+
+        const normalizedEmail = normalizeCredential(credentials.email, "Email");
+        const normalizedPassword = normalizeCredential(
+          credentials.password,
+          "Password"
+        );
+
+        const users = await getUser(normalizedEmail);
+
+        if (users.length === 0) {
+          const dummyPassword = await getDummyPassword();
+          await verifyPassword(normalizedPassword, dummyPassword);
           return null;
         }
 
@@ -72,7 +94,9 @@ export const {
           return null;
         }
 
-        return { ...user, type: "regular" };
+        const { password: _password, ...userWithoutPassword } = user;
+
+        return { ...userWithoutPassword, type: "regular" };
       },
     }),
     Credentials({

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -10,4 +10,12 @@ export const isTestEnvironment = Boolean(
 
 export const guestRegex = /^guest-\d+$/;
 
+let cachedDummyPassword: string | null = null;
 
+export const getDummyPassword = async (): Promise<string> => {
+  if (!cachedDummyPassword) {
+    cachedDummyPassword = await generateDummyPassword();
+  }
+
+  return cachedDummyPassword;
+};

--- a/lib/db/utils.ts
+++ b/lib/db/utils.ts
@@ -1,2 +1,24 @@
-import { hash } from "@node-rs/bcrypt";
 import { generateId } from "ai";
+
+import { hashPassword } from "../security/bcrypt";
+
+let cachedDummyPasswordPromise: Promise<string> | null = null;
+
+export const generateHashedPassword = async (
+  password: string,
+  cost?: number
+): Promise<string> => {
+  return hashPassword(password, cost);
+};
+
+const createDummyPassword = (): Promise<string> => {
+  return hashPassword(generateId());
+};
+
+export const generateDummyPassword = async (): Promise<string> => {
+  if (!cachedDummyPasswordPromise) {
+    cachedDummyPasswordPromise = createDummyPassword();
+  }
+
+  return cachedDummyPasswordPromise;
+};


### PR DESCRIPTION
## Summary
- repair the credentials authorize flow to validate normalized input, reuse the dummy password hash, and avoid returning stored hashes
- add a cached dummy password helper so failed lookups still perform bcrypt verification
- implement shared hashed password utilities backed by the existing bcrypt adapter

## Testing
- pnpm lint *(fails: repository has pre-existing formatting and lint violations outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_b_68d89e4825e48332a73076ad7c7d6dfc